### PR TITLE
feature/Fix_styled_text_substyle -> master

### DIFF
--- a/Sources/SwiftStylable/Classes/Style/Stylers/StyledTextStyler.swift
+++ b/Sources/SwiftStylable/Classes/Style/Stylers/StyledTextStyler.swift
@@ -36,7 +36,11 @@ class StyledTextStyler : Styler {
         }
         
         if let styledTextAttributes = style.styledTextStyle.styledTextAttributes {
-            view.styledTextAttributes = styledTextAttributes
+            if view.styledTextAttributes != nil {
+                styledTextAttributes.keys.forEach({ view.styledTextAttributes![$0] = styledTextAttributes[$0] })
+            } else {
+                view.styledTextAttributes = styledTextAttributes
+            }
         }
     }
 }


### PR DESCRIPTION
Bij de StopApp liep ik tegen het probleem op dat je niet maar 1 property van de styledTextAttributes kan overriden. Wanneer er een substyle is met styledTextAttributes dan zal deze de normale styledTextAttributes vervangen. 
Voorbeeld:
Ik heb label met een text style met een styledTextAttributes dictionary met daarin een lineSpacing en foregroundColor en ik zet een substyle met alleen een foregroundColor. Voor deze fix zou de lineSpacing property wegvallen omdat de dictionary wordt vervangen voor de dictionary van de substyle. 

Deze extra check zorgt ervoor dat elke key wordt langsgelopen en deze wordt toegevoegd wanneer er al items in de styledTextAttributes staan. 